### PR TITLE
fix dub build trial:runner

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -29,6 +29,7 @@
 			"targetName": "trial",
 			"sourcePaths": ["runner"],
 			"importPaths": ["runner"],
+			"stringImportPaths": ["lifecycle/trial"],
 
 			"dependencies": {
 				"dub": "~>1.3.0",
@@ -36,8 +37,6 @@
 				"fluent-asserts": "*",
 				"arsd-official:terminal": "~>1.2.1"
 			},
-
-			"dflags": [ "-Jlifecycle/trial" ]
 		}
 	]
 }


### PR DESCRIPTION
Try with
```sh
dub add-local trial
dub build trial:runner
```
That's the same build anyone else gets via `dub fetch trial` and `dub build trial:runner`.
Also that `:runner` subpackage should prolly be turned into the application config, so people can just `dub run trial` instead.
https://github.com/dlang/dub/wiki/Cookbook#creating-a-library-package-that-also-comes-with-an-executable
https://github.com/dlang/dub/issues/1155