### PR TITLE
Fix deprecation warnings

### DIFF
--- a/runner/trial/command.d
+++ b/runner/trial/command.d
@@ -200,6 +200,7 @@ class TrialDescribeCommand : TrialCommand {
 			import trial.discovery.testclass;
 			import trial.discovery.spec;
 			import trial.interfaces;
+			import std.array : array;
 
 			auto unitTestDiscovery = new UnitTestDiscovery;
 			auto testClassDiscovery = new TestClassDiscovery;


### PR DESCRIPTION
Fixes:
```
runner/trial/command.d(216,91): Deprecation: dub.compilers.buildsettings.array is not visible from module command
runner/trial/command.d(217,93): Deprecation: dub.compilers.buildsettings.array is not visible from module command
runner/trial/command.d(218,88): Deprecation: dub.compilers.buildsettings.array is not visible from module command
```